### PR TITLE
Can we remove #linguistics yet?

### DIFF
--- a/CHANNELS.md
+++ b/CHANNELS.md
@@ -69,7 +69,6 @@ Channel | Type | Purpose | Role Permissions
 #maths | :speech_balloon: | Discussion of maths or sharing (or asking for help) of problems | @everyone can read/write
 #science | :speech_balloon: | Discussion of all science topics that don't fit into other channels | @everyone can read/write
 #programming | :speech_balloon: | Discussion and help with programming | @everyone can read/write
-#linguistics | :speech_balloon: | Discussion of linguistics - leftover from April Fool's that was popular enough to leave, at least for the time being | @everyone can read/write
 
 ## Years
 Channel | Type | Purpose | Role Permissions


### PR DESCRIPTION
Please?

But in all seriousness; the channel was created for April Fool's day. It was great that it was used for a while afterwards, but it is now inactive and not seriously used, so I think it has run its course.